### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/navigation-display/index.ts
+++ b/src/navigation-display/index.ts
@@ -18,7 +18,7 @@ class NavigationDisplay {
 
   init() {
     const tagName = Tag.getMeta(this).name;
-    const uiState = Selectors.uiTagState(this.flux.store.getState(), tagName, this.props.field.value);
+    const uiState = this.select(Selectors.uiTagState, tagName, this.props.field.value);
     this.updateField(this.props.field);
     this.state = {
       ...this.state,
@@ -44,7 +44,7 @@ class NavigationDisplay {
   }
 
   selectNavigation(field: string): RefinementControls.SelectedNavigation {
-    const navigation = Selectors.navigation(this.flux.store.getState(), field);
+    const navigation = this.select(Selectors.navigation, field);
     return <any>{
       ...navigation,
       refinements: navigation.refinements.map((value, index) => ({

--- a/test/unit/navigation-display.ts
+++ b/test/unit/navigation-display.ts
@@ -32,7 +32,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
     it('should call updateField()', () => {
       const field = 'brand';
       const updateField = navigationDisplay.updateField = spy();
-      stub(Selectors, <any>'uiTagState').returns({});
+      navigationDisplay.select = spy(() => ({}));
       stub(Tag, 'getMeta').returns({});
       navigationDisplay.flux = <any>{
         on: () => null,
@@ -49,7 +49,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
       const globalState = { a: 'a' };
       const name = 'efgh';
       const value = 'abcd';
-      const uiTagState = stub(Selectors, <any>'uiTagState').returns({ isActive: false });
+      const select = navigationDisplay.select = spy(() => ({ isActive: false }));
       stub(Tag, 'getMeta').withArgs(navigationDisplay).returns({ name });
       navigationDisplay.updateField = () => null;
       navigationDisplay.flux = <any>{
@@ -60,7 +60,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
 
       navigationDisplay.init();
 
-      expect(uiTagState).to.be.calledWith(globalState, name, value);
+      expect(select).to.be.calledWith(Selectors.uiTagState, name, value);
       expect(navigationDisplay.state.isActive).to.be.false;
     });
 
@@ -68,7 +68,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
       const globalState = { a: 'a' };
       const name = 'efgh';
       const value = 'abcd';
-      const uiTagState = stub(Selectors, <any>'uiTagState');
+      const select = navigationDisplay.select = spy(() => undefined);
       stub(Tag, 'getMeta').withArgs(navigationDisplay).returns({ name });
       navigationDisplay.updateField = () => null;
       navigationDisplay.flux = <any>{
@@ -79,7 +79,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
 
       navigationDisplay.init();
 
-      expect(uiTagState).to.be.calledWith(globalState, name, value);
+      expect(select).to.be.calledWith(Selectors.uiTagState, name, value);
       expect(navigationDisplay.state.isActive).to.be.false;
     });
 
@@ -87,7 +87,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
       const on = spy();
       const name = 'efgh';
       const value = 'abcd';
-      stub(Selectors, 'uiTagState');
+      navigationDisplay.select = () => undefined;
       stub(Tag, 'getMeta').returns({ name });
       navigationDisplay.updateField = () => null;
       navigationDisplay.flux = <any>{
@@ -229,7 +229,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
       };
       const state = { i: 'j' };
       const field = 'brand';
-      const navigationSelector = stub(Selectors, 'navigation').returns(navigation);
+      const select = navigationDisplay.select = spy(() => navigation);
       navigationDisplay.flux = <any>{ store: { getState: () => state } };
 
       const refinements = navigationDisplay.selectNavigation(field);
@@ -245,7 +245,7 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldHaveAlias }) => {
         range: true,
         g: 'h'
       });
-      expect(navigationSelector).to.be.calledWithExactly(state, field);
+      expect(select).to.be.calledWithExactly(Selectors.navigation, field);
     });
   });
 

--- a/test/unit/range-selector.ts
+++ b/test/unit/range-selector.ts
@@ -77,5 +77,23 @@ suite('RangeSelector', ({ expect, spy, stub }) => {
 
       expect(switchRefinement).to.be.calledWithExactly(field, min, max);
     });
+
+    it('should not call switchRefinement with high NaN', () => {
+      const high = NaN;
+      const low = 5;
+      rangeSelector.props = {
+        values: {
+          high,
+          low,
+        },
+      };
+      rangeSelector.actions = <any>{
+        switchRefinement
+      };
+
+      rangeSelector.onClick();
+
+      expect(switchRefinement).to.not.be.called;
+    });
   });
 });


### PR DESCRIPTION
Also added a test to get to 100% coverage.
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
