### PR TITLE
feat(SF-1063): Add the option to always show total count badges on refinements

### DIFF
--- a/src/navigation-display/index.ts
+++ b/src/navigation-display/index.ts
@@ -61,6 +61,7 @@ class NavigationDisplay {
       or: navigation.or,
       range: navigation.range,
       selected: navigation.selected.includes(index),
+      alwaysShowTotal: this.props.field.alwaysShowTotals,
     });
 
     const navigation = this.select(Selectors.navigation, field);
@@ -107,6 +108,7 @@ namespace NavigationDisplay {
     display: Display;
     label: string;
     active: boolean;
+    alwaysShowTotals: boolean;
   }
 }
 

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -8,6 +8,7 @@ import NavigationList from '../navigation-list';
 @Core.tag('gb-navigation', require('./index.html'))
 class Navigation {
   props: Navigation.Props = {
+    alwaysShowTotals: false,
     display: {},
     labels: {},
     collapse: true,
@@ -39,6 +40,7 @@ class Navigation {
         display: this.props.display[value],
         label: this.props.labels[value],
         active: typeof isActive === 'boolean' ? isActive : index < isActive,
+        alwaysShowTotal: this.props.alwaysShowTotals,
       })),
     });
   };
@@ -47,6 +49,7 @@ class Navigation {
 interface Navigation extends Core.Tag<Navigation.Props, Navigation.State> {}
 namespace Navigation {
   export interface Props {
+    alwaysShowTotals: boolean;
     display: NavigationList.DisplayMap;
     labels: { [key: string]: string };
     collapse:

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -8,7 +8,7 @@ import NavigationList from '../navigation-list';
 @Core.tag('gb-navigation', require('./index.html'))
 class Navigation {
   props: Navigation.Props = {
-    alwaysShowTotals: true,
+    alwaysShowTotals: false,
     display: {},
     labels: {},
     collapse: true,

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -40,7 +40,7 @@ class Navigation {
         display: this.props.display[value],
         label: this.props.labels[value],
         active: typeof isActive === 'boolean' ? isActive : index < isActive,
-        alwaysShowTotal: this.props.alwaysShowTotals,
+        alwaysShowTotals: this.props.alwaysShowTotals,
       })),
     });
   };

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -8,7 +8,7 @@ import NavigationList from '../navigation-list';
 @Core.tag('gb-navigation', require('./index.html'))
 class Navigation {
   props: Navigation.Props = {
-    alwaysShowTotals: false,
+    alwaysShowTotals: true,
     display: {},
     labels: {},
     collapse: true,

--- a/src/refinement/index.html
+++ b/src/refinement/index.html
@@ -3,6 +3,6 @@
     <span if="{!props.or && props.selected}">&times;</span>
     <input show="{props.or}" type="{props.or ? 'checkbox' : 'button'}" checked="{props.selected}" onclick="{onClick}">
     <span class="gb-refinement__label">{props.range ? props.low + ' - ' + props.high : props.value}</span>
-    <gb-badge if="{!props.selected && props.total > 0}" _consumes="refinement">{$refinement.total}</gb-badge>
+    <gb-badge if="{!props.or || props.total}" total="{props.total}" _consumes="refinement">{props.total}</gb-badge>
   </label>
 </yield>

--- a/src/refinement/index.html
+++ b/src/refinement/index.html
@@ -3,6 +3,6 @@
     <span if="{!props.or && props.selected}">&times;</span>
     <input show="{props.or}" type="{props.or ? 'checkbox' : 'button'}" checked="{props.selected}" onclick="{onClick}">
     <span class="gb-refinement__label">{props.range ? props.low + ' - ' + props.high : props.value}</span>
-    <gb-badge if="{!props.or || props.total}" total="{props.total}" _consumes="refinement">{props.total}</gb-badge>
+    <gb-badge if="{state.total > 0 && (props.alwaysShowCount || !props.selected)}"  _consumes="refinementDisplay">{$refinementDisplay.total}</gb-badge>
   </label>
 </yield>

--- a/src/refinement/index.html
+++ b/src/refinement/index.html
@@ -1,7 +1,7 @@
 <yield>
   <label>
-    <span if="{!props.or && props.selected}">&times;</span>
-    <input show="{props.or}" type="{props.or ? 'checkbox' : 'button'}" checked="{props.selected}" onclick="{onClick}">
+    <span if="{state.cancelDisplay}">&times;</span>
+    <input show="{props.or}" type="{state.orType}" checked="{props.selected}" onclick="{onClick}">
     <span class="gb-refinement__label">{state.label}</span>
     <gb-badge if="{state.showTotal}"  _consumes="refinementDisplay">{$refinementDisplay.total}</gb-badge>
   </label>

--- a/src/refinement/index.html
+++ b/src/refinement/index.html
@@ -2,7 +2,7 @@
   <label>
     <span if="{!props.or && props.selected}">&times;</span>
     <input show="{props.or}" type="{props.or ? 'checkbox' : 'button'}" checked="{props.selected}" onclick="{onClick}">
-    <span class="gb-refinement__label">{props.range ? props.low + ' - ' + props.high : props.value}</span>
-    <gb-badge if="{state.total > 0 && (props.alwaysShowCount || !props.selected)}"  _consumes="refinementDisplay">{$refinementDisplay.total}</gb-badge>
+    <span class="gb-refinement__label">{state.label}</span>
+    <gb-badge if="{state.showTotal}"  _consumes="refinementDisplay">{$refinementDisplay.total}</gb-badge>
   </label>
 </yield>

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -1,11 +1,11 @@
-import { tag, Tag } from '@storefront/core';
+import { tag, Selectors, Tag } from '@storefront/core';
 import RefinementList from '../refinement-list';
 import ValueRefinementControls from '../value-refinement-controls';
 
 @tag('gb-refinement', require('./index.html'))
 class Refinement {
   getTotal() {
-    return this.props.total;
+    return this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total;
   }
 
   onClick(event: Refinement.IndexedClickEvent) {
@@ -20,6 +20,8 @@ interface Refinement extends Tag<Refinement.Props> {}
 namespace Refinement {
   export interface Props {
     onClick: () => void;
+    or: boolean;
+    selected: boolean;
     total: number;
   }
 

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -1,11 +1,25 @@
-import { tag, Selectors, Tag } from '@storefront/core';
+import { configurable, provide, tag, Selectors, Tag } from '@storefront/core';
 import RefinementList from '../refinement-list';
 import ValueRefinementControls from '../value-refinement-controls';
 
+@configurable
+@provide('refinementDisplay')
 @tag('gb-refinement', require('./index.html'))
 class Refinement {
-  getTotal() {
-    return this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total;
+  props: Refinement.Props = <Refinement.Props>{
+    alwaysShowCount: false,
+  };
+
+  state: Refinement.State = {
+    total: 0,
+  };
+
+  init() {
+    this.updateTotal();
+  }
+
+  onUpdate() {
+    this.updateTotal();
   }
 
   onClick(event: Refinement.IndexedClickEvent) {
@@ -14,14 +28,26 @@ class Refinement {
       this.props.onClick();
     }
   }
+
+  updateTotal() {
+    this.state = {
+      ...this.state,
+      total: this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total,
+    }
+  }
 }
 
 interface Refinement extends Tag<Refinement.Props> {}
 namespace Refinement {
   export interface Props {
+    alwaysShowCount: boolean;
     onClick: () => void;
     or: boolean;
     selected: boolean;
+    total: number;
+  }
+
+  export interface State {
     total: number;
   }
 

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -1,25 +1,35 @@
-import { configurable, provide, tag, Selectors, Tag } from '@storefront/core';
+import { configurable, provide, tag, Selectors, Store, Tag } from '@storefront/core';
 import RefinementList from '../refinement-list';
 import ValueRefinementControls from '../value-refinement-controls';
 
-@configurable
 @provide('refinementDisplay')
 @tag('gb-refinement', require('./index.html'))
 class Refinement {
-  props: Refinement.Props = <Refinement.Props>{
+  props: Refinement.Props = {
     alwaysShowTotal: false,
   };
 
   state: Refinement.State = {
     total: 0,
+    showTotal: false,
+    label: '',
   };
 
   init() {
-    this.updateTotal();
+    this.updateState();
   }
 
   onUpdate() {
-    this.updateTotal();
+    this.updateState();
+  }
+
+  updateState() {
+    this.state = {
+      ...this.state,
+      total: this.getTotal(),
+      showTotal: this.shouldShowTotal(),
+      label: this.getLabel(),
+    };
   }
 
   onClick(event: Refinement.IndexedClickEvent) {
@@ -29,26 +39,37 @@ class Refinement {
     }
   }
 
-  updateTotal() {
-    this.state = {
-      ...this.state,
-      total: this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total,
-    }
+  getTotal() {
+    return this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total;
+  }
+
+  shouldShowTotal() {
+    return this.state.total > 0 && (this.props.alwaysShowTotal || !this.props.selected);
+  }
+
+  getLabel() {
+    return this.props.range ? this.props.low + ' - ' + this.props.high : this.props.value;
   }
 }
 
 interface Refinement extends Tag<Refinement.Props> {}
 namespace Refinement {
   export interface Props {
-    alwaysShowTotal: boolean;
-    onClick: () => void;
-    or: boolean;
-    selected: boolean;
-    total: number;
+    alwaysShowTotal?: boolean;
+    onClick?: () => void;
+    or?: boolean;
+    selected?: boolean;
+    total?: number;
+    value?: string;
+    range?: boolean;
+    low?: number;
+    high?: number;
   }
 
   export interface State {
     total: number;
+    showTotal: boolean;
+    label: string;
   }
 
   export interface IndexedClickEvent extends Event, Tag.Event {

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -9,12 +9,6 @@ class Refinement {
     alwaysShowTotal: false,
   };
 
-  state: Refinement.State = {
-    total: 0,
-    showTotal: false,
-    label: '',
-  };
-
   init() {
     this.updateState();
   }
@@ -27,28 +21,24 @@ class Refinement {
     this.state = {
       ...this.state,
       total: this.getTotal(),
-      showTotal: this.shouldShowTotal(),
+      showTotal: this.getShowTotal(),
       label: this.getLabel(),
+      orType: this.getOrType(),
+      cancelDisplay: this.getCancelDisplay(),
     };
   }
+
+  getTotal = () => (this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total);
+  getShowTotal = () => this.getTotal() > 0 && (this.props.alwaysShowTotal || !this.props.selected);
+  getLabel = () => (this.props.range ? this.props.low + ' - ' + this.props.high : this.props.value);
+  getOrType = () => (this.props.or ? 'checkbox' : 'button');
+  getCancelDisplay = () => !this.props.or && !!this.props.selected;
 
   onClick(event: Refinement.IndexedClickEvent) {
     event.preventUpdate = true;
     if (this.props.onClick) {
       this.props.onClick();
     }
-  }
-
-  getTotal() {
-    return this.props.selected && !this.props.or ? this.select(Selectors.recordCount) : this.props.total;
-  }
-
-  shouldShowTotal() {
-    return this.getTotal() > 0 && (this.props.alwaysShowTotal || !this.props.selected);
-  }
-
-  getLabel() {
-    return this.props.range ? this.props.low + ' - ' + this.props.high : this.props.value;
   }
 }
 
@@ -70,6 +60,8 @@ namespace Refinement {
     total: number;
     showTotal: boolean;
     label: string;
+    orType: string;
+    cancelDisplay: boolean;
   }
 
   export interface IndexedClickEvent extends Event, Tag.Event {

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -7,7 +7,7 @@ import ValueRefinementControls from '../value-refinement-controls';
 @tag('gb-refinement', require('./index.html'))
 class Refinement {
   props: Refinement.Props = <Refinement.Props>{
-    alwaysShowCount: false,
+    alwaysShowTotal: false,
   };
 
   state: Refinement.State = {
@@ -40,7 +40,7 @@ class Refinement {
 interface Refinement extends Tag<Refinement.Props> {}
 namespace Refinement {
   export interface Props {
-    alwaysShowCount: boolean;
+    alwaysShowTotal: boolean;
     onClick: () => void;
     or: boolean;
     selected: boolean;

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -4,6 +4,10 @@ import ValueRefinementControls from '../value-refinement-controls';
 
 @tag('gb-refinement', require('./index.html'))
 class Refinement {
+  getTotal() {
+    return this.props.total;
+  }
+
   onClick(event: Refinement.IndexedClickEvent) {
     event.preventUpdate = true;
     if (this.props.onClick) {
@@ -16,6 +20,7 @@ interface Refinement extends Tag<Refinement.Props> {}
 namespace Refinement {
   export interface Props {
     onClick: () => void;
+    total: number;
   }
 
   export interface IndexedClickEvent extends Event, Tag.Event {

--- a/src/refinement/index.ts
+++ b/src/refinement/index.ts
@@ -1,4 +1,4 @@
-import { configurable, provide, tag, Selectors, Store, Tag } from '@storefront/core';
+import { provide, tag, Selectors, Store, Tag } from '@storefront/core';
 import RefinementList from '../refinement-list';
 import ValueRefinementControls from '../value-refinement-controls';
 
@@ -44,7 +44,7 @@ class Refinement {
   }
 
   shouldShowTotal() {
-    return this.state.total > 0 && (this.props.alwaysShowTotal || !this.props.selected);
+    return this.getTotal() > 0 && (this.props.alwaysShowTotal || !this.props.selected);
   }
 
   getLabel() {

--- a/test/unit/navigation-display.ts
+++ b/test/unit/navigation-display.ts
@@ -239,15 +239,16 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldProvideAlias }) => {
       const state = { i: 'j' };
       const field = 'brand';
       const select = (navigationDisplay.select = spy(() => navigation));
+      navigationDisplay.props.field = <any>{ alwaysShowTotals: false };
       navigationDisplay.flux = <any>{ store: { getState: () => state } };
 
       const refinements = navigationDisplay.selectNavigation(field);
 
       expect(refinements).to.eql({
         refinements: [
-          { a: 'b', index: 0, selected: true, or: false, range: true },
-          { c: 'd', index: 1, selected: false, or: false, range: true },
-          { e: 'f', index: 2, selected: true, or: false, range: true },
+          { a: 'b', index: 0, selected: true, or: false, range: true, alwaysShowTotal: false },
+          { c: 'd', index: 1, selected: false, or: false, range: true, alwaysShowTotal: false },
+          { e: 'f', index: 2, selected: true, or: false, range: true, alwaysShowTotal: false },
         ],
         selected: [0, 2],
         or: false,
@@ -269,18 +270,50 @@ suite('NavigationDisplay', ({ expect, spy, stub, itShouldProvideAlias }) => {
       const state = { i: 'j' };
       const field = 'brand';
       const select = (navigationDisplay.select = spy(() => navigation));
+      navigationDisplay.props.field = <any>{ alwaysShowTotals: false };
       navigationDisplay.flux = <any>{ store: { getState: () => state } };
 
       const refinements = navigationDisplay.selectNavigation(field);
 
       expect(refinements).to.eql({
         refinements: [
-          { a: 'b', index: 0, selected: true, or: false, range: true },
-          { e: 'f', index: 2, selected: true, or: false, range: true },
-          { c: 'd', index: 1, selected: false, or: false, range: true },
+          { a: 'b', index: 0, selected: true, or: false, range: true, alwaysShowTotal: false },
+          { e: 'f', index: 2, selected: true, or: false, range: true, alwaysShowTotal: false },
+          { c: 'd', index: 1, selected: false, or: false, range: true, alwaysShowTotal: false },
         ],
         selected: [0, 2],
         show: [0, 2, 1],
+        or: false,
+        range: true,
+        g: 'h',
+      });
+      expect(select).to.be.calledWithExactly(Selectors.navigation, field);
+    });
+
+    it('should mark the refinement to always show total if it is marked as such on the field', () => {
+      const navigation = {
+        refinements: [{ a: 'b' }, { c: 'd' }, { e: 'f' }],
+        selected: [0, 2],
+        or: false,
+        range: true,
+        g: 'h',
+      };
+      const state = { i: 'j' };
+      const field = 'brand';
+      const select = (navigationDisplay.select = spy(() => navigation));
+      const alwaysShowTotal = true;
+      navigationDisplay.props.field = <any>{ alwaysShowTotals: alwaysShowTotal };
+      navigationDisplay.flux = <any>{ store: { getState: () => state } };
+
+      const refinements = navigationDisplay.selectNavigation(field);
+
+      expect(refinements).to.eql({
+        refinements: [
+          { a: 'b', index: 0, selected: true, or: false, range: true, alwaysShowTotal },
+          { c: 'd', index: 1, selected: false, or: false, range: true, alwaysShowTotal },
+          { e: 'f', index: 2, selected: true, or: false, range: true, alwaysShowTotal },
+        ],
+        selected: [0, 2],
         or: false,
         range: true,
         g: 'h',

--- a/test/unit/navigation.ts
+++ b/test/unit/navigation.ts
@@ -13,7 +13,7 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
   describe('constructor()', () => {
     describe('props', () => {
       it('should set initial values', () => {
-        expect(navigation.props).to.eql({ display: {}, labels: {}, collapse: true, showOnlyAvailableNavHeaders: false });
+        expect(navigation.props).to.eql({ alwaysShowTotals: false, display: {}, labels: {}, collapse: true, showOnlyAvailableNavHeaders: false });
       });
     });
 
@@ -54,71 +54,71 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
     });
 
     it('should set fields, with active set for the first x number of fields based on isActive', () => {
-      navigation.props = <any>{ display, labels, collapse: { isActive: 2 } };
+      navigation.props = <any>{ display, labels, collapse: { isActive: 2 }, alwaysShowTotals: false };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true },
-          { value: 'b', display: 'range', label: 'B', active: true },
-          { value: 'c', display: undefined, label: 'C', active: false },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal: false },
         ],
       });
     });
 
     it('should set fields with active true when isActive true', () => {
-      navigation.props = <any>{ display, labels, collapse: { isActive: true } };
+      navigation.props = <any>{ display, labels, collapse: { isActive: true }, alwaysShowTotals: false };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true },
-          { value: 'b', display: 'range', label: 'B', active: true },
-          { value: 'c', display: undefined, label: 'C', active: true },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
         ],
       });
     });
 
     it('should set fields with active false when isActive false', () => {
-      navigation.props = <any>{ display, labels, collapse: { isActive: false } };
+      navigation.props = <any>{ display, labels, collapse: { isActive: false }, alwaysShowTotals: false };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: false },
-          { value: 'b', display: 'range', label: 'B', active: false },
-          { value: 'c', display: undefined, label: 'C', active: false },
+          { value: 'a', display: 'value', label: undefined, active: false, alwaysShowTotal: false },
+          { value: 'b', display: 'range', label: 'B', active: false, alwaysShowTotal: false },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal: false },
         ],
       });
     });
 
     it('should set fields with active true when collapse true', () => {
-      navigation.props = <any>{ display, labels, collapse: true };
+      navigation.props = <any>{ display, labels, collapse: true, alwaysShowTotals: false };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true },
-          { value: 'b', display: 'range', label: 'B', active: true },
-          { value: 'c', display: undefined, label: 'C', active: true },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
         ],
       });
     });
 
     it('should set fields with active true when collapse false', () => {
-      navigation.props = <any>{ display, labels, collapse: false };
+      navigation.props = <any>{ display, labels, collapse: false, alwaysShowTotals: false };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true },
-          { value: 'b', display: 'range', label: 'B', active: true },
-          { value: 'c', display: undefined, label: 'C', active: true },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
         ],
       });
     });
@@ -130,6 +130,7 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
         labels: { d: undefined, e: 'B' },
         collapse: false,
         showOnlyAvailableNavHeaders: true,
+        alwaysShowTotals: false,
       };
 
       navigation.updateFields(navigationsObject);
@@ -137,8 +138,24 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
       expect(navigationSelect).to.be.calledWith(Selectors.availableNavigations);
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'd', display: 'value', label: undefined, active: true },
-          { value: 'e', display: 'range', label: 'B', active: true },
+          { value: 'd', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
+          { value: 'e', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+        ],
+      });
+    });
+
+    it('should add', () => {
+      const alwaysShowTotals = true;
+      const alwaysShowTotal = alwaysShowTotals;
+      navigation.props = <any>{ display, labels, collapse: { isActive: 2 }, alwaysShowTotals };
+
+      navigation.updateFields(navigationsObject);
+
+      expect(set).to.be.calledWith({
+        fields: [
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal },
         ],
       });
     });

--- a/test/unit/navigation.ts
+++ b/test/unit/navigation.ts
@@ -60,9 +60,9 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
-          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
-          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal: false },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotals: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotals: false },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotals: false },
         ],
       });
     });
@@ -74,9 +74,9 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
-          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
-          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotals: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotals: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotals: false },
         ],
       });
     });
@@ -88,9 +88,9 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: false, alwaysShowTotal: false },
-          { value: 'b', display: 'range', label: 'B', active: false, alwaysShowTotal: false },
-          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal: false },
+          { value: 'a', display: 'value', label: undefined, active: false, alwaysShowTotals: false },
+          { value: 'b', display: 'range', label: 'B', active: false, alwaysShowTotals: false },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotals: false },
         ],
       });
     });
@@ -102,9 +102,9 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
-          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
-          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotals: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotals: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotals: false },
         ],
       });
     });
@@ -116,9 +116,9 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
-          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
-          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotal: false },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotals: false },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotals: false },
+          { value: 'c', display: undefined, label: 'C', active: true, alwaysShowTotals: false },
         ],
       });
     });
@@ -138,24 +138,23 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
       expect(navigationSelect).to.be.calledWith(Selectors.availableNavigations);
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'd', display: 'value', label: undefined, active: true, alwaysShowTotal: false },
-          { value: 'e', display: 'range', label: 'B', active: true, alwaysShowTotal: false },
+          { value: 'd', display: 'value', label: undefined, active: true, alwaysShowTotals: false },
+          { value: 'e', display: 'range', label: 'B', active: true, alwaysShowTotals: false },
         ],
       });
     });
 
     it('should add', () => {
       const alwaysShowTotals = true;
-      const alwaysShowTotal = alwaysShowTotals;
       navigation.props = <any>{ display, labels, collapse: { isActive: 2 }, alwaysShowTotals };
 
       navigation.updateFields(navigationsObject);
 
       expect(set).to.be.calledWith({
         fields: [
-          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotal },
-          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotal },
-          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotal },
+          { value: 'a', display: 'value', label: undefined, active: true, alwaysShowTotals },
+          { value: 'b', display: 'range', label: 'B', active: true, alwaysShowTotals },
+          { value: 'c', display: undefined, label: 'C', active: false, alwaysShowTotals },
         ],
       });
     });

--- a/test/unit/navigation.ts
+++ b/test/unit/navigation.ts
@@ -13,7 +13,13 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
   describe('constructor()', () => {
     describe('props', () => {
       it('should set initial values', () => {
-        expect(navigation.props).to.eql({ alwaysShowTotals: false, display: {}, labels: {}, collapse: true, showOnlyAvailableNavHeaders: false });
+        expect(navigation.props).to.eql({
+          alwaysShowTotals: true,
+          display: {},
+          labels: {},
+          collapse: true,
+          showOnlyAvailableNavHeaders: false,
+        });
       });
     });
 
@@ -124,7 +130,7 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
     });
 
     it('should use only available navigations if showOnlyAvailableNavHeaders is true', () => {
-      const navigationSelect = navigation.select = spy(() => [{ field: 'd' }, { field: 'e' }]);
+      const navigationSelect = (navigation.select = spy(() => [{ field: 'd' }, { field: 'e' }]));
       navigation.props = <any>{
         display: { d: 'value', e: 'range' },
         labels: { d: undefined, e: 'B' },

--- a/test/unit/navigation.ts
+++ b/test/unit/navigation.ts
@@ -14,7 +14,7 @@ suite('Navigation', ({ expect, spy, itShouldBeConfigurable, itShouldProvideAlias
     describe('props', () => {
       it('should set initial values', () => {
         expect(navigation.props).to.eql({
-          alwaysShowTotals: true,
+          alwaysShowTotals: false,
           display: {},
           labels: {},
           collapse: true,

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -12,7 +12,7 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
   describe('constructor()', () => {
     describe('props', () => {
       it('should set initial values', () => {
-        expect(refinement.props).to.eql({ alwaysShowCount: false });
+        expect(refinement.props).to.eql({ alwaysShowTotal: false });
       });
     });
 

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -18,11 +18,20 @@ suite('Refinement', ({ expect, spy, stub }) => {
 
     it('should call props.onClick()', () => {
       const onClick = spy();
-      refinement.props = { onClick };
+      refinement.props = <any>{ onClick };
 
       refinement.onClick(<any>{});
 
       expect(onClick).to.be.called;
+    });
+  });
+
+  describe('getTotal()', () => {
+    it('should return the total if it exists', () => {
+      const total = 1024;
+      refinement.props = <any>{ total };
+
+      expect(refinement.getTotal()).to.eq(total);
     });
   });
 });

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -15,22 +15,12 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
         expect(refinement.props).to.eql({ alwaysShowTotal: false });
       });
     });
-
-    describe('state', () => {
-      it('should set initial value', () => {
-        expect(refinement.state).to.eql({
-          total: 0,
-          showTotal: false,
-          label: '',
-        });
-      });
-    });
   });
 
   describe('init()', () => {
     it('should set state', () => {
       const total = 1024;
-      const updateState = refinement.updateState = spy();
+      const updateState = (refinement.updateState = spy());
 
       refinement.init();
 
@@ -41,7 +31,7 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
   describe('onUpdate()', () => {
     it('should update the total', () => {
       const total = 1024;
-      const updateState = refinement.updateState = spy();
+      const updateState = (refinement.updateState = spy());
 
       refinement.onUpdate();
 
@@ -51,18 +41,28 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
 
   describe('updateState()', () => {
     it('should update the state', () => {
-      const total = 1024;
+      const total = 100;
       const showTotal = true;
-      const label = 'value'
-      const getTotal = refinement.getTotal = () => total;
-      const shouldShowTotal = refinement.shouldShowTotal = () => showTotal;
-      const getLabel = refinement.getLabel = () => label;
-      refinement.props = <any>{ value: label };
+      const label = 'ok';
+      const orType = 'button';
+      const cancelDisplay = true;
+      stub(refinement, 'getTotal').returns(total);
+      stub(refinement, 'getShowTotal').returns(showTotal);
+      stub(refinement, 'getLabel').returns(label);
+      stub(refinement, 'getOrType').returns(orType);
+      stub(refinement, 'getCancelDisplay').returns(cancelDisplay);
       refinement.state = <any>{ a: 'b' };
 
       refinement.updateState();
 
-      expect(refinement.state).to.eql({ a: 'b', total, showTotal, label });
+      expect(refinement.state).to.eql({
+        a: 'b',
+        total,
+        showTotal,
+        label,
+        orType,
+        cancelDisplay,
+      });
     });
   });
 
@@ -90,7 +90,7 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
     it('should return the total if it exists', () => {
       const total = 1024;
       refinement.props = <any>{ total };
-      refinement.shouldShowTotal = () => true;
+      refinement.getShowTotal = () => true;
 
       expect(refinement.getTotal()).to.eq(total);
     });
@@ -98,7 +98,7 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
     it('should return the record count if the refinement is selected and not or-able', () => {
       const count = 1024;
       refinement.select = () => count;
-      refinement.shouldShowTotal = () => true;
+      refinement.getShowTotal = () => true;
       refinement.props = <any>{
         or: false,
         selected: true,
@@ -108,34 +108,36 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
     });
   });
 
-  describe('shouldShowTotal()', () => {
+  describe('getShowTotal()', () => {
     const truthTable = [
       { total: 0, alwaysShowTotal: false, selected: false, or: false, expected: false },
-      { total: 0, alwaysShowTotal: false, selected: false, or:  true, expected: false },
-      { total: 0, alwaysShowTotal: false, selected:  true, or: false, expected: false },
-      { total: 0, alwaysShowTotal: false, selected:  true, or:  true, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected: false, or: false, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected: false, or:  true, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected:  true, or: false, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected: false, or:  true, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected:  true, or: false, expected: false },
-      { total: 0, alwaysShowTotal:  true, selected:  true, or:  true, expected: false },
-      { total: 1, alwaysShowTotal: false, selected: false, or: false, expected:  true },
-      { total: 1, alwaysShowTotal: false, selected: false, or:  true, expected:  true },
-      { total: 1, alwaysShowTotal: false, selected:  true, or: false, expected: false },
-      { total: 1, alwaysShowTotal: false, selected:  true, or:  true, expected: false },
-      { total: 1, alwaysShowTotal:  true, selected: false, or: false, expected:  true },
-      { total: 1, alwaysShowTotal:  true, selected: false, or:  true, expected:  true },
-      { total: 1, alwaysShowTotal:  true, selected:  true, or: false, expected:  true },
-      { total: 1, alwaysShowTotal:  true, selected:  true, or:  true, expected:  true },
+      { total: 0, alwaysShowTotal: false, selected: false, or: true, expected: false },
+      { total: 0, alwaysShowTotal: false, selected: true, or: false, expected: false },
+      { total: 0, alwaysShowTotal: false, selected: true, or: true, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: false, or: false, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: false, or: true, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: true, or: false, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: false, or: true, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: true, or: false, expected: false },
+      { total: 0, alwaysShowTotal: true, selected: true, or: true, expected: false },
+      { total: 1, alwaysShowTotal: false, selected: false, or: false, expected: true },
+      { total: 1, alwaysShowTotal: false, selected: false, or: true, expected: true },
+      { total: 1, alwaysShowTotal: false, selected: true, or: false, expected: false },
+      { total: 1, alwaysShowTotal: false, selected: true, or: true, expected: false },
+      { total: 1, alwaysShowTotal: true, selected: false, or: false, expected: true },
+      { total: 1, alwaysShowTotal: true, selected: false, or: true, expected: true },
+      { total: 1, alwaysShowTotal: true, selected: true, or: false, expected: true },
+      { total: 1, alwaysShowTotal: true, selected: true, or: true, expected: true },
     ];
 
-    truthTable.forEach(({ total, alwaysShowTotal, selected, or, expected}) => {
-      it(`should return ${expected} for total: ${total ? '>0' : '0'}, alwaysShowTotal: ${alwaysShowTotal}, selected: ${selected}, or: ${or}`, () => {
+    truthTable.forEach(({ total, alwaysShowTotal, selected, or, expected }) => {
+      it(`should return ${expected} for total: ${
+        total ? '>0' : '0'
+      }, alwaysShowTotal: ${alwaysShowTotal}, selected: ${selected}, or: ${or}`, () => {
         refinement.props = { alwaysShowTotal, selected, or };
         refinement.getTotal = () => total;
 
-        expect(refinement.shouldShowTotal()).to.eq(expected);
+        expect(refinement.getShowTotal()).to.eq(expected);
       });
     });
   });
@@ -156,6 +158,42 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
       };
 
       expect(refinement.getLabel()).to.eq('4 - 10');
+    });
+  });
+
+  describe('getOrType()', () => {
+    it('should return "checkbox"', () => {
+      refinement.props = { or: true };
+
+      expect(refinement.getOrType()).to.eq('checkbox');
+    });
+
+    it('should return "button"', () => {
+      refinement.props = { or: false };
+
+      expect(refinement.getOrType()).to.eq('button');
+    });
+  });
+
+  describe('getCancelDisplay()', () => {
+    it('should return true', () => {
+      refinement.props = { or: false, selected: true };
+
+      expect(refinement.getCancelDisplay()).to.eq(true);
+    });
+
+    it('should return false', () => {
+      refinement.props = { or: true, selected: true };
+
+      expect(refinement.getCancelDisplay()).to.eq(false);
+
+      refinement.props = { or: true, selected: false };
+
+      expect(refinement.getCancelDisplay()).to.eq(false);
+
+      refinement.props = { or: false, selected: false };
+
+      expect(refinement.getCancelDisplay()).to.eq(false);
     });
   });
 });

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -2,10 +2,49 @@ import { Selectors } from '@storefront/core';
 import Refinement from '../../src/refinement';
 import suite from './_suite';
 
-suite('Refinement', ({ expect, spy, stub }) => {
+suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
   let refinement: Refinement;
 
   beforeEach(() => (refinement = new Refinement()));
+
+  itShouldProvideAlias(Refinement, 'refinementDisplay');
+
+  describe('constructor()', () => {
+    describe('props', () => {
+      it('should set initial values', () => {
+        expect(refinement.props).to.eql({ alwaysShowCount: false });
+      });
+    });
+
+    describe('state', () => {
+      it('should set initial value', () => {
+        expect(refinement.state).to.eql({ total: 0 });
+      });
+    });
+  });
+
+  describe('init()', () => {
+    it('should set state', () => {
+      const total = 1024;
+      const updateTotal = refinement.updateTotal = spy();
+
+      refinement.init();
+
+      expect(updateTotal).to.be.called;
+    });
+  });
+
+  describe('onUpdate()', () => {
+    it('should update the total', () => {
+      const total = 1024;
+      const updateTotal = refinement.updateTotal = spy();
+      refinement.state = <any>{ total: 1 };
+
+      refinement.onUpdate();
+
+      expect(updateTotal).to.be.called;
+    });
+  });
 
   describe('onClick()', () => {
     it('should set preventUpdate', () => {
@@ -27,12 +66,14 @@ suite('Refinement', ({ expect, spy, stub }) => {
     });
   });
 
-  describe('getTotal()', () => {
+  describe('updateTotal()', () => {
     it('should return the total if it exists', () => {
       const total = 1024;
       refinement.props = <any>{ total };
 
-      expect(refinement.getTotal()).to.eq(total);
+      refinement.updateTotal();
+
+      expect(refinement.state).to.eql({ total });
     });
 
     it('should return the record count if the refinement is selected and not or-able', () => {
@@ -43,7 +84,9 @@ suite('Refinement', ({ expect, spy, stub }) => {
         selected: true,
       };
 
-      expect(refinement.getTotal()).to.eq(count);
+      refinement.updateTotal();
+
+      expect(refinement.state).to.eql({ total: count });
     });
   });
 });

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -133,7 +133,7 @@ suite('Refinement', ({ expect, spy, stub, itShouldProvideAlias }) => {
     truthTable.forEach(({ total, alwaysShowTotal, selected, or, expected}) => {
       it(`should return ${expected} for total: ${total ? '>0' : '0'}, alwaysShowTotal: ${alwaysShowTotal}, selected: ${selected}, or: ${or}`, () => {
         refinement.props = { alwaysShowTotal, selected, or };
-        refinement.state = <any>{ total };
+        refinement.getTotal = () => total;
 
         expect(refinement.shouldShowTotal()).to.eq(expected);
       });

--- a/test/unit/refinement.ts
+++ b/test/unit/refinement.ts
@@ -1,3 +1,4 @@
+import { Selectors } from '@storefront/core';
 import Refinement from '../../src/refinement';
 import suite from './_suite';
 
@@ -32,6 +33,17 @@ suite('Refinement', ({ expect, spy, stub }) => {
       refinement.props = <any>{ total };
 
       expect(refinement.getTotal()).to.eq(total);
+    });
+
+    it('should return the record count if the refinement is selected and not or-able', () => {
+      const count = 1024;
+      refinement.select = spy(() => count);
+      refinement.props = <any>{
+        or: false,
+        selected: true,
+      };
+
+      expect(refinement.getTotal()).to.eq(count);
     });
   });
 });


### PR DESCRIPTION
A new boolean prop on `gb-refinement` called `alwaysShowTotal` (false by default) allows the total count badge to always appear. The exceptions are when the total is 0 or when the refinement would be returned as part of a "more refinements" call.

The Refinement component has been made configurable to allow this prop to be configured once for all instances of the component.

To access the total in child components, the component's state has been aliased to `refinementDisplay`.